### PR TITLE
Allow "parcel" 

### DIFF
--- a/packages/import-utils/src/create-sandbox/templates.ts
+++ b/packages/import-utils/src/create-sandbox/templates.ts
@@ -138,7 +138,10 @@ export function getTemplate(
     return "styleguidist";
   }
 
-  if (totalDependencies.indexOf("parcel-bundler") > -1) {
+  if (
+    totalDependencies.indexOf("parcel-bundler") > -1 || 
+    totalDependencies.indexOf("parcel") > -1
+  ) {
     return "parcel";
   }
 


### PR DESCRIPTION
Thank you for good service.

`parcel-bundler` has alias `parcel` but current can't detected.