### PR TITLE
Allow commit URLs

### DIFF
--- a/packages/git-extractor/src/index.ts
+++ b/packages/git-extractor/src/index.ts
@@ -35,7 +35,7 @@ router
   .get("/git/github/rights/:username/:repo", github.getRights)
   .get("/git/github/info/:username/:repo/tree/:branch/:path*", github.info) // allow tree urls
   .get("/git/github/info/:username/:repo/blob/:branch/:path*", github.info) // allow blob urls
-  .get("/git/github/info/:username/:repo/commit/:branch/:path*", github.info) // allow commit urls
+  .get("/git/github/info/:username/:repo/commit/:branch", github.info) // allow commit urls
   .get("/git/github/info/:username/:repo", github.info) // For when tree isn't in path (root path)
   .get("/git/github/info/:username/:repo/pull/:pull", github.pullInfo) // allow pull urls
   // Push

--- a/packages/git-extractor/src/index.ts
+++ b/packages/git-extractor/src/index.ts
@@ -35,6 +35,7 @@ router
   .get("/git/github/rights/:username/:repo", github.getRights)
   .get("/git/github/info/:username/:repo/tree/:branch/:path*", github.info) // allow tree urls
   .get("/git/github/info/:username/:repo/blob/:branch/:path*", github.info) // allow blob urls
+  .get("/git/github/info/:username/:repo/commit/:branch/:path*", github.info) // allow commit urls
   .get("/git/github/info/:username/:repo", github.info) // For when tree isn't in path (root path)
   .get("/git/github/info/:username/:repo/pull/:pull", github.pullInfo) // allow pull urls
   // Push


### PR DESCRIPTION
Allow importing GitHub commit URLs e.g. `https://codesandbox.io/s/github/excalidraw/excalidraw/commit/dc0a4f4cb8bf85a541a9a1a85c7cf60dfac362c9` . Fixes https://github.com/codesandbox/codesandbox-client/issues/3379 .