### PR TITLE
Use Node template when importing a project using tfjs-node

### DIFF
--- a/packages/import-utils/src/create-sandbox/templates.ts
+++ b/packages/import-utils/src/create-sandbox/templates.ts
@@ -176,7 +176,7 @@ export function getTemplate(
     return "cxjs";
   }
 
-  const nodeDeps = ["express", "koa", "nodemon", "ts-node"];
+  const nodeDeps = ["express", "koa", "nodemon", "ts-node", "tfjs-node"];
   if (totalDependencies.some(dep => nodeDeps.indexOf(dep) > -1)) {
     return "node";
   }


### PR DESCRIPTION
Projects using @tensorflow/tfjs-node require a container.