### PR TITLE
New flow

### DIFF
--- a/lerna-debug.log
+++ b/lerna-debug.log
@@ -1,0 +1,36 @@
+0 silly input [ 'build' ]
+1 silly flags { _: [ 'run' ],
+1 silly flags   'reject-cycles': false,
+1 silly flags   rejectCycles: false,
+1 silly flags   parallel: true,
+1 silly flags   scope: [ 'codesandbox', 'git-converter' ],
+1 silly flags   script: 'build',
+1 silly flags   args: [] }
+2 verbose rootPath /Users/christianalfoni/Development/codesandbox-importers
+3 info version 2.11.0
+4 silly existsSync /Users/christianalfoni/Development/codesandbox-importers/VERSION
+5 info scope [ 'codesandbox', 'git-converter' ]
+6 silly initialize attempt
+7 silly initialize success
+8 silly execute attempt
+9 info run in 2 package(s): npm run build
+10 silly runScriptInPackageStreaming [ 'build', [], 'codesandbox' ]
+11 silly getExecOpts { cwd:
+11 silly getExecOpts    '/Users/christianalfoni/Development/codesandbox-importers/packages/cli' }
+12 silly runScriptInPackageStreaming [ 'build', [], 'git-converter' ]
+13 silly getExecOpts { cwd:
+13 silly getExecOpts    '/Users/christianalfoni/Development/codesandbox-importers/packages/git-extractor' }
+14 error execute callback with error
+15 error Error: Command failed: yarn run build
+15 error error Command failed with exit code 2.
+15 error error Command failed with exit code 2.
+15 error
+15 error $ rimraf dist && yarn compile
+15 error $ tsc
+15 error src/routes/github/api.ts(650,31): error TS2304: Cannot find name 'username'.
+15 error src/routes/github/api.ts(650,41): error TS2304: Cannot find name 'repo'.
+15 error src/routes/github/api.ts(650,47): error TS2304: Cannot find name 'pull'.
+15 error info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+15 error info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+15 error
+15 error     at Promise.all.then.arr (/Users/christianalfoni/Development/codesandbox-importers/node_modules/lerna/node_modules/execa/index.js:236:11)

--- a/packages/git-extractor/src/index.ts
+++ b/packages/git-extractor/src/index.ts
@@ -1,24 +1,21 @@
-import * as Koa from "koa";
-import * as Router from "koa-router";
 import * as Sentry from "@sentry/node";
-
+import * as Koa from "koa";
 import * as bodyParser from "koa-bodyparser";
+import * as Router from "koa-router";
 
-import log from "./utils/log";
-
+import camelize from "./middleware/camelize";
+import decamelize from "./middleware/decamelize";
+import errorHandler from "./middleware/error-handler";
 // MIDDLEWARE
 import logger from "./middleware/logger";
-import errorHandler from "./middleware/error-handler";
-import decamelize from "./middleware/decamelize";
-import camelize from "./middleware/camelize";
 import notFound from "./middleware/not-found";
-
+import * as define from "./routes/define";
 // ROUTES
 import * as github from "./routes/github";
-import * as define from "./routes/define";
+import log from "./utils/log";
 
 Sentry.init({
-  dsn: "https://4917ce43c4ca42a1acb85b2843b79c6b@sentry.io/4377691"
+  dsn: "https://4917ce43c4ca42a1acb85b2843b79c6b@sentry.io/4377691",
 });
 
 const DEFAULT_PORT = process.env.PORT || 2000;
@@ -43,6 +40,7 @@ router
   .get("/git/github/info/:username/:repo/commit/:branch", github.info) // allow commit urls
   .get("/git/github/info/:username/:repo", github.info) // For when tree isn't in path (root path)
   .get("/git/github/info/:username/:repo/pull/:pull", github.pullInfo) // allow pull urls
+  .get("/git/github/compare/:username/:repo/:branch", github.compare)
   // Push
   .post("/git/github/diff/:username/:repo/:branch*/path/:path*", github.diff)
   .post(
@@ -57,3 +55,36 @@ app.use(router.routes()).use(router.allowedMethods());
 
 log(`Listening on ${DEFAULT_PORT}`);
 app.listen(DEFAULT_PORT);
+
+/*
+    # 1 Create repo
+    - Review github.data // Download existing
+    - Review github.repo // Create new one
+    - Review github.info // General info about the repo, not sure when it is used? To get latest commit sha maybe?
+    
+    # 2 Create PR
+    - Review github.getRights
+    - Review github.pr
+
+    # 3 Update PR
+    - Review github.commit
+
+    # 4 Status of PR
+    - Review github.pullInfo
+
+    # 5 Conflict 
+    - To get files changed between two commits. Related to updating a PR where SHA is different
+      https://developer.github.com/v3/repos/commits/#compare-two-commits
+    - How to get the files in conflict on a PR? 
+
+
+Okay, so these are the changes I need:
+
+# post("/git/github/pr/:username/:repo/:branch*\/path/:path*", github.pr)
+- Pass in sandboxId as well on the payload, this will become the branch name
+- As I understand the correct branch will now be returned as well so that further commits will go to this branch
+
+# get("/git/github/info/:username/:repo/pull/:pull", github.pullInfo)
+- Also needs to return the new "merged", "mergeable" and "rebaseable"
+
+*/

--- a/packages/git-extractor/src/index.ts
+++ b/packages/git-extractor/src/index.ts
@@ -40,7 +40,7 @@ router
   .get("/git/github/info/:username/:repo/commit/:branch", github.info) // allow commit urls
   .get("/git/github/info/:username/:repo", github.info) // For when tree isn't in path (root path)
   .get("/git/github/info/:username/:repo/pull/:pull", github.pullInfo) // allow pull urls
-  .post("/git/github/compare/:username/:repo/:branch", github.compare) // Compare changes between branches and commits
+  .post("/git/github/compare/:username/:repo", github.compare) // Compare changes between branches and commits
   // Push
   .post(
     "/git/github/commit/:username/:repo/:branch*/path/:path*",

--- a/packages/git-extractor/src/index.ts
+++ b/packages/git-extractor/src/index.ts
@@ -42,7 +42,6 @@ router
   .get("/git/github/info/:username/:repo/pull/:pull", github.pullInfo) // allow pull urls
   .post("/git/github/compare/:username/:repo/:branch", github.compare) // Compare changes between branches and commits
   // Push
-  .post("/git/github/diff/:username/:repo/:branch*/path/:path*", github.diff)
   .post(
     "/git/github/commit/:username/:repo/:branch*/path/:path*",
     github.commit

--- a/packages/git-extractor/src/index.ts
+++ b/packages/git-extractor/src/index.ts
@@ -40,7 +40,7 @@ router
   .get("/git/github/info/:username/:repo/commit/:branch", github.info) // allow commit urls
   .get("/git/github/info/:username/:repo", github.info) // For when tree isn't in path (root path)
   .get("/git/github/info/:username/:repo/pull/:pull", github.pullInfo) // allow pull urls
-  .get("/git/github/compare/:username/:repo/:branch", github.compare)
+  .post("/git/github/compare/:username/:repo/:branch", github.compare) // Compare changes between branches and commits
   // Push
   .post("/git/github/diff/:username/:repo/:branch*/path/:path*", github.diff)
   .post(
@@ -55,36 +55,3 @@ app.use(router.routes()).use(router.allowedMethods());
 
 log(`Listening on ${DEFAULT_PORT}`);
 app.listen(DEFAULT_PORT);
-
-/*
-    # 1 Create repo
-    - Review github.data // Download existing
-    - Review github.repo // Create new one
-    - Review github.info // General info about the repo, not sure when it is used? To get latest commit sha maybe?
-    
-    # 2 Create PR
-    - Review github.getRights
-    - Review github.pr
-
-    # 3 Update PR
-    - Review github.commit
-
-    # 4 Status of PR
-    - Review github.pullInfo
-
-    # 5 Conflict 
-    - To get files changed between two commits. Related to updating a PR where SHA is different
-      https://developer.github.com/v3/repos/commits/#compare-two-commits
-    - How to get the files in conflict on a PR? 
-
-
-Okay, so these are the changes I need:
-
-# post("/git/github/pr/:username/:repo/:branch*\/path/:path*", github.pr)
-- Pass in sandboxId as well on the payload, this will become the branch name
-- As I understand the correct branch will now be returned as well so that further commits will go to this branch
-
-# get("/git/github/info/:username/:repo/pull/:pull", github.pullInfo)
-- Also needs to return the new "merged", "mergeable" and "rebaseable"
-
-*/

--- a/packages/git-extractor/src/middleware/error-handler.ts
+++ b/packages/git-extractor/src/middleware/error-handler.ts
@@ -6,7 +6,10 @@ const errorHandler = async (ctx: Context, next: () => Promise<any>) => {
     await next();
   } catch (e) {
     ctx.status = e.status || (e.response && e.response.status) || 500;
-    ctx.body = { error: e.message };
+    ctx.body = {
+      error:
+        e.response && e.response.data ? e.response.data.message : e.message,
+    };
 
     if (e.response && e.response.data) {
       console.log("ERROR: " + e.response.data.message);

--- a/packages/git-extractor/src/middleware/error-handler.ts
+++ b/packages/git-extractor/src/middleware/error-handler.ts
@@ -14,8 +14,6 @@ const errorHandler = async (ctx: Context, next: () => Promise<any>) => {
     if (e.response && e.response.data) {
       console.log("ERROR: " + e.response.data.message);
     }
-
-    ctx.app.emit("error", e, ctx);
   }
 };
 

--- a/packages/git-extractor/src/routes/github/api.ts
+++ b/packages/git-extractor/src/routes/github/api.ts
@@ -335,23 +335,13 @@ export async function createPr(
   body: string,
   token: string
 ): Promise<IPrResponse> {
-  console.log("Calling CREATE PR");
-  console.log({
-    base: `${base.username === head.username ? "" : base.username + ":"}${
-      base.branch
-    }`,
-    head: head.branch,
-    title,
-    body,
-    maintainer_can_modify: true,
-  });
   const { data } = await axios.post(
     `${buildRepoApiUrl(head.username, head.repo)}/pulls`,
     {
-      base: `${base.username === head.username ? "" : base.username + ":"}${
+      base: base.branch,
+      head: `${base.username === head.username ? "" : base.username + ":"}${
         base.branch
       }`,
-      head: head.branch,
       title,
       body,
       maintainer_can_modify: true,

--- a/packages/git-extractor/src/routes/github/api.ts
+++ b/packages/git-extractor/src/routes/github/api.ts
@@ -349,7 +349,7 @@ export async function createPr(
   );
 
   return {
-    number: data.id,
+    number: data.number,
     repo: data.head.repo.name,
     username: data.head.repo.owner.login,
     commitSha: data.head.sha,

--- a/packages/git-extractor/src/routes/github/api.ts
+++ b/packages/git-extractor/src/routes/github/api.ts
@@ -97,6 +97,7 @@ interface ICompareResponse {
   merge_base_commit: {
     sha: string;
   };
+  commits: Array<{ sha: string }>;
 }
 
 interface IContentResponse {

--- a/packages/git-extractor/src/routes/github/api.ts
+++ b/packages/git-extractor/src/routes/github/api.ts
@@ -336,7 +336,7 @@ export async function createPr(
   token: string
 ): Promise<IPrResponse> {
   const { data } = await axios.post(
-    `${buildRepoApiUrl(head.username, head.repo)}/pulls`,
+    `${buildRepoApiUrl(base.username, base.repo)}/pulls`,
     {
       base: base.branch,
       head: `${base.username === head.username ? "" : head.username + ":"}${

--- a/packages/git-extractor/src/routes/github/api.ts
+++ b/packages/git-extractor/src/routes/github/api.ts
@@ -349,7 +349,7 @@ export async function createPr(
   );
 
   return {
-    number: data.head.number,
+    number: data.id,
     repo: data.head.repo.name,
     username: data.head.repo.owner.login,
     commitSha: data.head.sha,

--- a/packages/git-extractor/src/routes/github/api.ts
+++ b/packages/git-extractor/src/routes/github/api.ts
@@ -335,6 +335,16 @@ export async function createPr(
   body: string,
   token: string
 ): Promise<IPrResponse> {
+  console.log("Calling CREATE PR");
+  console.log({
+    base: `${base.username === head.username ? "" : base.username + ":"}${
+      base.branch
+    }`,
+    head: head.branch,
+    title,
+    body,
+    maintainer_can_modify: true,
+  });
   const { data } = await axios.post(
     `${buildRepoApiUrl(head.username, head.repo)}/pulls`,
     {

--- a/packages/git-extractor/src/routes/github/api.ts
+++ b/packages/git-extractor/src/routes/github/api.ts
@@ -335,15 +335,6 @@ export async function createPr(
   body: string,
   token: string
 ): Promise<IPrResponse> {
-  console.log({
-    base: base.branch,
-    head: `${base.username === head.username ? "" : base.username + ":"}${
-      base.branch
-    }`,
-    title,
-    body,
-    maintainer_can_modify: true,
-  });
   const { data } = await axios.post(
     `${buildRepoApiUrl(head.username, head.repo)}/pulls`,
     {

--- a/packages/git-extractor/src/routes/github/api.ts
+++ b/packages/git-extractor/src/routes/github/api.ts
@@ -335,21 +335,12 @@ export async function createPr(
   body: string,
   token: string
 ): Promise<IPrResponse> {
-  console.log({
-    base: base.branch,
-    head: `${base.username === head.username ? "" : base.username + ":"}${
-      base.branch
-    }`,
-    title,
-    body,
-    maintainer_can_modify: true,
-  });
   const { data } = await axios.post(
     `${buildRepoApiUrl(head.username, head.repo)}/pulls`,
     {
       base: base.branch,
-      head: `${base.username === head.username ? "" : base.username + ":"}${
-        base.branch
+      head: `${base.username === head.username ? "" : head.username + ":"}${
+        head.branch
       }`,
       title,
       body,

--- a/packages/git-extractor/src/routes/github/api.ts
+++ b/packages/git-extractor/src/routes/github/api.ts
@@ -98,6 +98,7 @@ interface IPrResponse {
   mergeable: boolean;
   mergeable_state: string;
   commitSha: string;
+  baseCommitSha: string;
   rebaseable: boolean;
   commits: number;
   additions: number;
@@ -317,6 +318,7 @@ export async function createPr(
     additions: data.additions,
     changed_files: data.changed_files,
     commits: data.commits,
+    baseCommitSha: data.base.sha,
     deletions: data.deletions,
   };
 }
@@ -736,6 +738,7 @@ export async function fetchPullInfo(
       additions: data.additions,
       changed_files: data.changed_files,
       commits: data.commits,
+      baseCommitSha: data.base.sha,
       deletions: data.deletions,
     };
   } catch (e) {

--- a/packages/git-extractor/src/routes/github/api.ts
+++ b/packages/git-extractor/src/routes/github/api.ts
@@ -119,6 +119,7 @@ interface IPrResponse {
   repo: string;
   username: string;
   branch: string;
+  state: string;
   merged: boolean;
   mergeable: boolean;
   mergeable_state: string;
@@ -356,6 +357,7 @@ export async function createPr(
     commitSha: data.head.sha,
     branch: data.head.ref,
     merged: data.merged,
+    state: data.state,
     mergeable: data.mergeable,
     mergeable_state: data.mergeable_state,
     rebaseable: data.rebaseable,
@@ -706,6 +708,7 @@ export async function fetchPullInfo(
       username: data.head.repo.owner.login,
       commitSha: data.head.sha,
       branch: data.head.ref,
+      state: data.state,
       merged: data.merged,
       mergeable: data.mergeable,
       mergeable_state: data.mergeable_state,

--- a/packages/git-extractor/src/routes/github/api.ts
+++ b/packages/git-extractor/src/routes/github/api.ts
@@ -335,6 +335,15 @@ export async function createPr(
   body: string,
   token: string
 ): Promise<IPrResponse> {
+  console.log({
+    base: base.branch,
+    head: `${base.username === head.username ? "" : base.username + ":"}${
+      base.branch
+    }`,
+    title,
+    body,
+    maintainer_can_modify: true,
+  });
   const { data } = await axios.post(
     `${buildRepoApiUrl(head.username, head.repo)}/pulls`,
     {

--- a/packages/git-extractor/src/routes/github/api.ts
+++ b/packages/git-extractor/src/routes/github/api.ts
@@ -39,13 +39,10 @@ function buildContentsApiUrl(username: string, repo: string, path: string) {
 function buildCompareApiUrl(
   username: string,
   repo: string,
-  branch: string,
-  base: { ref: string; username: string }
+  baseRef: string,
+  headRef: string
 ) {
-  return `${buildRepoApiUrl(username, repo)}/compare/${
-    // We only prefix with username if we are comparing with a source repo of different user (PR)
-    base.username === username ? base.ref : `${base.username}:${base.ref}`
-  }...${branch}`;
+  return `${buildRepoApiUrl(username, repo)}/compare/${baseRef}...${headRef}`;
 }
 
 function buildSecretParams() {
@@ -94,6 +91,12 @@ interface ICompareResponse {
     changes: number;
     contents_url: string;
   }>;
+  base_commit: {
+    sha: string;
+  };
+  merge_base_commit: {
+    sha: string;
+  };
 }
 
 interface IContentResponse {
@@ -136,11 +139,11 @@ interface IDeleteContentResponse {
 export async function getComparison(
   username: string,
   repo: string,
-  branch: string,
-  base: { ref: string; username: string },
+  baseRef: string,
+  headRef: string,
   token: string
 ) {
-  const url = buildCompareApiUrl(username, repo, branch, base);
+  const url = buildCompareApiUrl(username, repo, baseRef, headRef);
 
   console.log("GETTING COMPARISON", url);
   const response: { data: ICompareResponse } = await axios({

--- a/packages/git-extractor/src/routes/github/index.ts
+++ b/packages/git-extractor/src/routes/github/index.ts
@@ -244,7 +244,7 @@ export const pr = async (ctx: Context) => {
 };
 
 export const commit = async (ctx: Context) => {
-  const { parent_commit_shas, changes, message, token } = ctx.request.body;
+  const { parentCommitShas, changes, message, token } = ctx.request.body;
   const { username, repo, branch, path } = ctx.params;
 
   const gitInfo: IGitInfo = {
@@ -257,7 +257,7 @@ export const commit = async (ctx: Context) => {
   const commit = await push.createCommit(
     gitInfo,
     changes,
-    parent_commit_shas,
+    parentCommitShas,
     message,
     token
   );

--- a/packages/git-extractor/src/routes/github/index.ts
+++ b/packages/git-extractor/src/routes/github/index.ts
@@ -137,6 +137,8 @@ export const compare = async (ctx: Context) => {
   const { base, token, include_contents } = ctx.request.body;
   const { username, repo, branch } = ctx.params;
 
+  console.log("WTF?", ctx.params, ctx.request.body);
+
   const comparison = await getComparison(username, repo, branch, base, token);
 
   if (include_contents) {

--- a/packages/git-extractor/src/routes/github/index.ts
+++ b/packages/git-extractor/src/routes/github/index.ts
@@ -221,12 +221,12 @@ export const pr = async (ctx: Context) => {
   );
 
   const res = await push.createBranch(gitInfo, commit.sha, token, sandboxId);
-  const base = {
+  const head = {
     branch,
     repo,
     username,
   };
-  const head = {
+  const base = {
     branch: res.branchName,
     repo: gitInfo.repo,
     username: gitInfo.username,

--- a/packages/git-extractor/src/routes/github/index.ts
+++ b/packages/git-extractor/src/routes/github/index.ts
@@ -156,7 +156,7 @@ export const compare = async (ctx: Context) => {
       baseCommitSha: comparison.base_commit.sha,
       headCommitSha: comparison.commits.length
         ? comparison.commits[0].sha
-        : comparison.merge_base_commit,
+        : comparison.merge_base_commit.sha,
     };
   } else {
     ctx.body = {
@@ -172,7 +172,7 @@ export const compare = async (ctx: Context) => {
       baseCommitSha: comparison.base_commit.sha,
       headCommitSha: comparison.commits.length
         ? comparison.commits[0].sha
-        : comparison.merge_base_commit,
+        : comparison.merge_base_commit.sha,
     };
   }
 };

--- a/packages/git-extractor/src/routes/github/index.ts
+++ b/packages/git-extractor/src/routes/github/index.ts
@@ -145,32 +145,61 @@ export const data = async (ctx: Context, next: () => Promise<any>) => {
 /*
   Compares a base commit against the branch of the repo. This base commit can be:
   1. The latest commit SHA in the Sandbox PR vs the PR branch (The Sandbox PR is out of sync with latest commits of PR branch)
-  2. The latest commit SHA in the Sandbox source vs the PR branch (The sandbox PR is not mergable due to "dirty" mergeable_state)
+  2. The branch of the Sandbox source vs the PR branch (The sandbox PR is not mergable due to "dirty" mergeable_state)
   3. The original commit SHA forked from the Sandbox source vs the PR branch (All changes made in the PR)
 
   The combination of 2 and 3 can filter out exactly what files are in conflict with the source.
 
   type Base {
-    commitSha: string
+    // We use commitSha when checking Sandbox PR against Github
+    // We use branch when checking conflicts
+    ref: string
     username: string
   }
 */
 export const compare = async (ctx: Context) => {
-  const { base, token } = ctx.request.body;
+  const { base, token, includeContents } = ctx.request.body;
   const { username, repo, branch } = ctx.params;
 
   const comparison = await getComparison(username, repo, branch, base, token);
 
-  return Promise.all(
-    comparison.files.map((file) => {
-      return api.getContent(file.contents_url, token).then((content) => {
-        return {
-          ...file,
-          content,
-        };
-      });
-    })
-  );
+  if (includeContents) {
+    const files = await Promise.all(
+      comparison.files.map(
+        ({ additions, changes, contents_url, deletions, filename, status }) => {
+          return api.getContent(contents_url, token).then((content) => {
+            const data = content.content;
+            const buffer = Buffer.from(data, content.encoding);
+
+            return {
+              additions,
+              changes,
+              deletions,
+              filename,
+              status,
+              content: buffer.toString("utf-8"),
+            };
+          });
+        }
+      )
+    );
+
+    ctx.body = {
+      files,
+    };
+  } else {
+    ctx.body = {
+      files: comparison.files.map(
+        ({ additions, status, filename, deletions, changes }) => ({
+          additions,
+          status,
+          filename,
+          deletions,
+          changes,
+        })
+      ),
+    };
+  }
 };
 
 export const diff = async (ctx: Context, next: () => Promise<any>) => {

--- a/packages/git-extractor/src/routes/github/index.ts
+++ b/packages/git-extractor/src/routes/github/index.ts
@@ -224,7 +224,7 @@ export const pr = async (ctx: Context) => {
   const commit = await push.createInitialCommit(
     gitInfo,
     relativeChanges,
-    commitSha,
+    [commitSha],
     token
   );
 

--- a/packages/git-extractor/src/routes/github/index.ts
+++ b/packages/git-extractor/src/routes/github/index.ts
@@ -136,9 +136,6 @@ export const data = async (ctx: Context, next: () => Promise<any>) => {
 export const compare = async (ctx: Context) => {
   const { base, token, include_contents } = ctx.request.body;
   const { username, repo, branch } = ctx.params;
-
-  console.log("WTF?", ctx.params, ctx.request.body);
-
   const comparison = await getComparison(username, repo, branch, base, token);
 
   if (include_contents) {

--- a/packages/git-extractor/src/routes/github/index.ts
+++ b/packages/git-extractor/src/routes/github/index.ts
@@ -120,7 +120,7 @@ export const data = async (ctx: Context, next: () => Promise<any>) => {
   Compares two refs on the repo
 */
 export const compare = async (ctx: Context) => {
-  const { baseRef, headRef, token, include_contents } = ctx.request.body;
+  const { baseRef, headRef, token, includeContents } = ctx.request.body;
   const { username, repo } = ctx.params;
   const comparison = await getComparison(
     username,
@@ -130,7 +130,7 @@ export const compare = async (ctx: Context) => {
     token
   );
 
-  if (include_contents) {
+  if (includeContents) {
     const files = await Promise.all(
       comparison.files.map(
         ({ additions, changes, contents_url, deletions, filename, status }) => {

--- a/packages/git-extractor/src/routes/github/index.ts
+++ b/packages/git-extractor/src/routes/github/index.ts
@@ -1,3 +1,4 @@
+import { IModule, INormalizedModules } from "codesandbox-import-util-types";
 import createSandbox from "codesandbox-import-utils/lib/create-sandbox";
 import { Context } from "koa";
 
@@ -275,14 +276,22 @@ export const commit = async (ctx: Context) => {
 export const repo = async (ctx: Context, next: () => Promise<any>) => {
   const {
     token,
-    changes,
+    normalizedFiles: fileArray,
     privateRepo,
   }: {
     token: string;
-    changes: IChanges;
+    normalizedFiles: Array<IModule & { path: string }>;
     privateRepo?: boolean;
   } = ctx.request.body;
   const { username, repo } = ctx.params;
+
+  const normalizedFiles: INormalizedModules = fileArray.reduce(
+    (total, file) => ({
+      ...total,
+      [file.path]: file,
+    }),
+    {}
+  );
 
   if (!repo) {
     throw new Error("Repo name cannot be empty");
@@ -291,7 +300,7 @@ export const repo = async (ctx: Context, next: () => Promise<any>) => {
   const result = await push.createRepo(
     username,
     repo,
-    changes,
+    normalizedFiles,
     token,
     privateRepo
   );

--- a/packages/git-extractor/src/routes/github/index.ts
+++ b/packages/git-extractor/src/routes/github/index.ts
@@ -244,7 +244,7 @@ export const pr = async (ctx: Context) => {
 };
 
 export const commit = async (ctx: Context) => {
-  const { changes, message, token } = ctx.request.body;
+  const { parentCommitShas, changes, message, token } = ctx.request.body;
   const { username, repo, branch, path } = ctx.params;
 
   const gitInfo: IGitInfo = {
@@ -254,19 +254,10 @@ export const commit = async (ctx: Context) => {
     path,
   };
 
-  const response = await api.fetchRepoInfo(
-    gitInfo.username,
-    gitInfo.repo,
-    gitInfo.branch,
-    path,
-    true,
-    token
-  );
-
   const commit = await push.createCommit(
     gitInfo,
     changes,
-    response.commitSha,
+    parentCommitShas,
     message,
     token
   );

--- a/packages/git-extractor/src/routes/github/index.ts
+++ b/packages/git-extractor/src/routes/github/index.ts
@@ -1,13 +1,11 @@
-import { Context } from "koa";
+import { IModule, INormalizedModules } from "codesandbox-import-util-types";
 import createSandbox from "codesandbox-import-utils/lib/create-sandbox";
 import normalizeSandbox from "codesandbox-import-utils/lib/utils/files/normalize";
-import { IModule, INormalizedModules } from "codesandbox-import-util-types";
+import { Context } from "koa";
 
-import { downloadRepository } from "./pull/download";
 import * as api from "./api";
-
+import { downloadRepository } from "./pull/download";
 import * as push from "./push";
-
 import { IGitInfo } from "./push";
 
 const getUserToken = (ctx: Context) => {
@@ -67,7 +65,7 @@ export const getRights = async (ctx: Context) => {
   );
 
   ctx.body = {
-    permission: rights
+    permission: rights,
   };
 };
 
@@ -95,7 +93,7 @@ export const data = async (ctx: Context, next: () => Promise<any>) => {
       username,
       repo,
       branch,
-      path
+      path,
     },
     commitSha,
     userToken
@@ -125,7 +123,7 @@ export const data = async (ctx: Context, next: () => Promise<any>) => {
     title: finalTitle,
 
     // Privacy 2 is private, privacy 0 is public
-    privacy: isPrivate ? 2 : 0
+    privacy: isPrivate ? 2 : 0,
   };
 };
 
@@ -143,14 +141,14 @@ export const diff = async (ctx: Context, next: () => Promise<any>) => {
       normalizedFiles,
       token
     ),
-    api.fetchRights(username, repo, token)
+    api.fetchRights(username, repo, token),
   ]);
 
   ctx.body = {
     added: delta.added,
     modified: delta.modified,
     deleted: delta.deleted,
-    rights
+    rights,
   };
 };
 
@@ -161,7 +159,8 @@ export const pr = async (ctx: Context, next: () => Promise<any>) => {
     commitSha,
     message,
     currentUser,
-    token
+    token,
+    sandboxId,
   } = ctx.request.body;
   const normalizedFiles = normalizeSandbox(modules, directories);
 
@@ -171,7 +170,7 @@ export const pr = async (ctx: Context, next: () => Promise<any>) => {
     username,
     repo,
     branch,
-    path
+    path,
   };
 
   const rights = await api.fetchRights(username, repo, token);
@@ -189,12 +188,12 @@ export const pr = async (ctx: Context, next: () => Promise<any>) => {
     token
   );
 
-  const res = await push.createBranch(gitInfo, commit.sha, token);
+  const res = await push.createBranch(gitInfo, commit.sha, token, sandboxId);
 
   ctx.body = {
     url: res.url,
     newBranch: res.branchName,
-    sha: commit.sha
+    sha: commit.sha,
   };
 };
 
@@ -208,7 +207,7 @@ export const commit = async (ctx: Context, next: () => Promise<any>) => {
     username,
     repo,
     branch,
-    path
+    path,
   };
 
   const commit = await push.createCommit(
@@ -247,7 +246,7 @@ export const commit = async (ctx: Context, next: () => Promise<any>) => {
       ctx.body = {
         url: res.url,
         sha: commit.sha,
-        merge: false
+        merge: false,
       };
       return;
     } catch (e) {
@@ -270,7 +269,7 @@ export const commit = async (ctx: Context, next: () => Promise<any>) => {
     ctx.body = {
       url: res.url,
       sha: res.sha,
-      merge: true
+      merge: true,
     };
     return;
   } catch (e) {
@@ -281,7 +280,7 @@ export const commit = async (ctx: Context, next: () => Promise<any>) => {
       ctx.body = {
         url: res.url,
         sha: commit.sha,
-        newBranch: res.branchName
+        newBranch: res.branchName,
       };
       return;
     } else {
@@ -294,7 +293,7 @@ export const repo = async (ctx: Context, next: () => Promise<any>) => {
   const {
     token,
     normalizedFiles: fileArray,
-    privateRepo
+    privateRepo,
   }: {
     token: string;
     normalizedFiles: Array<IModule & { path: string }>;
@@ -305,7 +304,7 @@ export const repo = async (ctx: Context, next: () => Promise<any>) => {
   const normalizedFiles: INormalizedModules = fileArray.reduce(
     (total, file) => ({
       ...total,
-      [file.path]: file
+      [file.path]: file,
     }),
     {}
   );

--- a/packages/git-extractor/src/routes/github/index.ts
+++ b/packages/git-extractor/src/routes/github/index.ts
@@ -244,7 +244,7 @@ export const pr = async (ctx: Context) => {
 };
 
 export const commit = async (ctx: Context) => {
-  const { parentCommitShas, changes, message, token } = ctx.request.body;
+  const { parent_commit_shas, changes, message, token } = ctx.request.body;
   const { username, repo, branch, path } = ctx.params;
 
   const gitInfo: IGitInfo = {
@@ -257,7 +257,7 @@ export const commit = async (ctx: Context) => {
   const commit = await push.createCommit(
     gitInfo,
     changes,
-    parentCommitShas,
+    parent_commit_shas,
     message,
     token
   );

--- a/packages/git-extractor/src/routes/github/index.ts
+++ b/packages/git-extractor/src/routes/github/index.ts
@@ -210,7 +210,7 @@ export const pr = async (ctx: Context) => {
     commitSha,
     currentUser,
     token,
-    sandboxId,
+    sandbox_id,
   } = ctx.request.body;
   const normalizedFiles = normalizeSandbox(modules, directories);
 
@@ -238,7 +238,7 @@ export const pr = async (ctx: Context) => {
     token
   );
 
-  const res = await push.createBranch(gitInfo, commit.sha, token, sandboxId);
+  const res = await push.createBranch(gitInfo, commit.sha, token, sandbox_id);
 
   ctx.body = await api.createPr(
     {

--- a/packages/git-extractor/src/routes/github/index.ts
+++ b/packages/git-extractor/src/routes/github/index.ts
@@ -243,7 +243,12 @@ export const pr = async (ctx: Context) => {
     token
   );
 
-  const res = await push.createBranch(gitInfo, commit.sha, token, sandboxId);
+  const res = await push.createBranch(
+    gitInfo,
+    commit.sha,
+    token,
+    `csb-${sandboxId}`
+  );
   const base = {
     branch,
     repo,

--- a/packages/git-extractor/src/routes/github/index.ts
+++ b/packages/git-extractor/src/routes/github/index.ts
@@ -205,10 +205,9 @@ export const pr = async (ctx: Context) => {
   const {
     modules,
     directories,
-    base,
-    head,
     title,
     description,
+    commitSha,
     currentUser,
     token,
     sandboxId,
@@ -234,14 +233,28 @@ export const pr = async (ctx: Context) => {
   const commit = await push.createCommit(
     gitInfo,
     normalizedFiles,
-    base.commitSha,
+    commitSha,
     "initial commit",
     token
   );
 
-  await push.createBranch(gitInfo, commit.sha, token, sandboxId);
+  const res = await push.createBranch(gitInfo, commit.sha, token, sandboxId);
 
-  ctx.body = await api.createPr(base, head, title, description, token);
+  ctx.body = await api.createPr(
+    {
+      branch,
+      repo,
+      username,
+    },
+    {
+      branch: res.branchName,
+      repo: gitInfo.repo,
+      username: gitInfo.username,
+    },
+    title,
+    description,
+    token
+  );
 };
 
 export const commit = async (ctx: Context, next: () => Promise<any>) => {

--- a/packages/git-extractor/src/routes/github/index.ts
+++ b/packages/git-extractor/src/routes/github/index.ts
@@ -178,7 +178,7 @@ export const pr = async (ctx: Context) => {
     changes,
     title,
     description,
-    parentCommitSha,
+    commitSha,
     currentUser,
     token,
     sandboxId,
@@ -186,7 +186,7 @@ export const pr = async (ctx: Context) => {
     changes: IChanges;
     title: string;
     description: string;
-    parentCommitSha: string;
+    commitSha: string;
     currentUser: string;
     token: string;
     sandboxId: string;
@@ -224,7 +224,7 @@ export const pr = async (ctx: Context) => {
   const commit = await push.createInitialCommit(
     gitInfo,
     relativeChanges,
-    parentCommitSha,
+    commitSha,
     token
   );
 

--- a/packages/git-extractor/src/routes/github/index.ts
+++ b/packages/git-extractor/src/routes/github/index.ts
@@ -206,20 +206,6 @@ export const pr = async (ctx: Context) => {
     path,
   };
 
-  const relativeChanges: IChanges = {
-    added: changes.added.map((change) => ({
-      ...change,
-      path: `${gitInfo.path ? gitInfo.path : ""}${change.path}`,
-    })),
-    modified: changes.modified.map((change) => ({
-      ...change,
-      path: `${gitInfo.path ? gitInfo.path : ""}${change.path}`,
-    })),
-    deleted: changes.deleted.map(
-      (path) => `${gitInfo.path ? gitInfo.path : ""}${path}`
-    ),
-  };
-
   const rights = await api.fetchRights(username, repo, token);
 
   if (rights === "none" || rights === "read") {
@@ -229,7 +215,7 @@ export const pr = async (ctx: Context) => {
 
   const commit = await push.createInitialCommit(
     gitInfo,
-    relativeChanges,
+    changes,
     [commitSha],
     token
   );

--- a/packages/git-extractor/src/routes/github/index.ts
+++ b/packages/git-extractor/src/routes/github/index.ts
@@ -244,7 +244,7 @@ export const pr = async (ctx: Context) => {
 };
 
 export const commit = async (ctx: Context) => {
-  const { changes, parentCommitSha, message, token } = ctx.request.body;
+  const { changes, message, token } = ctx.request.body;
   const { username, repo, branch, path } = ctx.params;
 
   const gitInfo: IGitInfo = {
@@ -263,14 +263,10 @@ export const commit = async (ctx: Context) => {
     token
   );
 
-  if (response.commitSha !== parentCommitSha) {
-    return ctx.throw("out of sync", 403);
-  }
-
   const commit = await push.createCommit(
     gitInfo,
     changes,
-    parentCommitSha,
+    response.commitSha,
     message,
     token
   );

--- a/packages/git-extractor/src/routes/github/index.ts
+++ b/packages/git-extractor/src/routes/github/index.ts
@@ -134,12 +134,12 @@ export const data = async (ctx: Context, next: () => Promise<any>) => {
   }
 */
 export const compare = async (ctx: Context) => {
-  const { base, token, includeContents } = ctx.request.body;
+  const { base, token, include_contents } = ctx.request.body;
   const { username, repo, branch } = ctx.params;
 
   const comparison = await getComparison(username, repo, branch, base, token);
 
-  if (includeContents) {
+  if (include_contents) {
     const files = await Promise.all(
       comparison.files.map(
         ({ additions, changes, contents_url, deletions, filename, status }) => {

--- a/packages/git-extractor/src/routes/github/index.ts
+++ b/packages/git-extractor/src/routes/github/index.ts
@@ -117,19 +117,7 @@ export const data = async (ctx: Context, next: () => Promise<any>) => {
 };
 
 /*
-  Compares a base commit against the branch of the repo. This base commit can be:
-  1. The latest commit SHA in the Sandbox PR vs the PR branch (The Sandbox PR is out of sync with latest commits of PR branch)
-  2. The branch of the Sandbox source vs the PR branch (The sandbox PR is not mergable due to "dirty" mergeable_state)
-  3. The original commit SHA forked from the Sandbox source vs the PR branch (All changes made in the PR)
-
-  The combination of 2 and 3 can filter out exactly what files are in conflict with the source.
-
-  type Base {
-    // We use commitSha when checking Sandbox PR against Github
-    // We use branch when checking conflicts
-    ref: string
-    username: string
-  }
+  Compares two refs on the repo
 */
 export const compare = async (ctx: Context) => {
   const { baseRef, headRef, token, include_contents } = ctx.request.body;

--- a/packages/git-extractor/src/routes/github/index.ts
+++ b/packages/git-extractor/src/routes/github/index.ts
@@ -132,9 +132,15 @@ export const data = async (ctx: Context, next: () => Promise<any>) => {
   }
 */
 export const compare = async (ctx: Context) => {
-  const { base, token, include_contents } = ctx.request.body;
-  const { username, repo, branch } = ctx.params;
-  const comparison = await getComparison(username, repo, branch, base, token);
+  const { baseRef, headRef, token, include_contents } = ctx.request.body;
+  const { username, repo } = ctx.params;
+  const comparison = await getComparison(
+    username,
+    repo,
+    baseRef,
+    headRef,
+    token
+  );
 
   if (include_contents) {
     const files = await Promise.all(
@@ -159,6 +165,8 @@ export const compare = async (ctx: Context) => {
 
     ctx.body = {
       files,
+      baseCommitSha: comparison.base_commit.sha,
+      headCommitSha: comparison.merge_base_commit.sha,
     };
   } else {
     ctx.body = {
@@ -171,6 +179,8 @@ export const compare = async (ctx: Context) => {
           changes,
         })
       ),
+      baseCommitSha: comparison.base_commit.sha,
+      headCommitSha: comparison.merge_base_commit.sha,
     };
   }
 };

--- a/packages/git-extractor/src/routes/github/index.ts
+++ b/packages/git-extractor/src/routes/github/index.ts
@@ -37,37 +37,13 @@ export const info = async (ctx: Context, next: () => Promise<any>) => {
 
 export const pullInfo = async (ctx: Context, next: () => Promise<any>) => {
   const userToken = getUserToken(ctx);
-  const {
-    username,
-    repo,
-    branch,
-    merged,
-    mergeable,
-    mergeable_state,
-    rebaseable,
-  } = await api.fetchPullInfo(
+
+  ctx.body = await api.fetchPullInfo(
     ctx.params.username,
     ctx.params.repo,
     ctx.params.pull,
     userToken
   );
-
-  const response = await api.fetchRepoInfo(
-    username,
-    repo,
-    branch,
-    "",
-    false,
-    userToken
-  );
-
-  ctx.body = {
-    ...response,
-    merged,
-    mergeable,
-    mergeable_state,
-    rebaseable,
-  };
 };
 
 export const getRights = async (ctx: Context) => {
@@ -225,12 +201,14 @@ export const diff = async (ctx: Context, next: () => Promise<any>) => {
   };
 };
 
-export const pr = async (ctx: Context, next: () => Promise<any>) => {
+export const pr = async (ctx: Context) => {
   const {
     modules,
     directories,
-    commitSha,
-    message,
+    base,
+    head,
+    title,
+    description,
     currentUser,
     token,
     sandboxId,
@@ -256,18 +234,14 @@ export const pr = async (ctx: Context, next: () => Promise<any>) => {
   const commit = await push.createCommit(
     gitInfo,
     normalizedFiles,
-    commitSha,
-    message,
+    base.commitSha,
+    "initial commit",
     token
   );
 
-  const res = await push.createBranch(gitInfo, commit.sha, token, sandboxId);
+  await push.createBranch(gitInfo, commit.sha, token, sandboxId);
 
-  ctx.body = {
-    url: res.url,
-    newBranch: res.branchName,
-    sha: commit.sha,
-  };
+  ctx.body = await api.createPr(base, head, title, description, token);
 };
 
 export const commit = async (ctx: Context, next: () => Promise<any>) => {

--- a/packages/git-extractor/src/routes/github/index.ts
+++ b/packages/git-extractor/src/routes/github/index.ts
@@ -221,12 +221,12 @@ export const pr = async (ctx: Context) => {
   );
 
   const res = await push.createBranch(gitInfo, commit.sha, token, sandboxId);
-  const head = {
+  const base = {
     branch,
     repo,
     username,
   };
-  const base = {
+  const head = {
     branch: res.branchName,
     repo: gitInfo.repo,
     username: gitInfo.username,

--- a/packages/git-extractor/src/routes/github/index.ts
+++ b/packages/git-extractor/src/routes/github/index.ts
@@ -154,7 +154,9 @@ export const compare = async (ctx: Context) => {
     ctx.body = {
       files,
       baseCommitSha: comparison.base_commit.sha,
-      headCommitSha: comparison.merge_base_commit.sha,
+      headCommitSha: comparison.commits.length
+        ? comparison.commits[0].sha
+        : comparison.merge_base_commit,
     };
   } else {
     ctx.body = {
@@ -168,7 +170,9 @@ export const compare = async (ctx: Context) => {
         })
       ),
       baseCommitSha: comparison.base_commit.sha,
-      headCommitSha: comparison.merge_base_commit.sha,
+      headCommitSha: comparison.commits.length
+        ? comparison.commits[0].sha
+        : comparison.merge_base_commit,
     };
   }
 };

--- a/packages/git-extractor/src/routes/github/push/index.ts
+++ b/packages/git-extractor/src/routes/github/push/index.ts
@@ -179,7 +179,7 @@ export async function createRepo(
   userToken: string,
   privateRepo?: boolean
 ) {
-  const data = await api.createRepo(username, name, userToken, privateRepo);
+  await api.createRepo(username, name, userToken, privateRepo);
 
   const latestData = await api.fetchRepoInfo(
     username,

--- a/packages/git-extractor/src/routes/github/push/index.ts
+++ b/packages/git-extractor/src/routes/github/push/index.ts
@@ -162,7 +162,7 @@ export async function createRepo(
   userToken: string,
   privateRepo?: boolean
 ) {
-  const data = await api.createRepo(username, name, userToken, privateRepo);
+  await api.createRepo(username, name, userToken, privateRepo);
 
   const latestData = await api.fetchRepoInfo(
     username,
@@ -188,7 +188,7 @@ export async function createRepo(
     userToken
   );
 
-  const res = await api.updateReference(
+  await api.updateReference(
     username,
     gitInfo.repo,
     gitInfo.branch,

--- a/packages/git-extractor/src/routes/github/push/utils/create-blobs.ts
+++ b/packages/git-extractor/src/routes/github/push/utils/create-blobs.ts
@@ -1,8 +1,8 @@
+import { IModule, INormalizedModules } from "codesandbox-import-util-types";
 import fetch from "node-fetch";
-import { INormalizedModules, IModule } from "codesandbox-import-util-types";
 
-import { IGitInfo, ITree } from "../index";
 import { createBlob } from "../../api";
+import { IGitInfo, ITree } from "../index";
 
 async function downloadContent(module: IModule): Promise<string> {
   if (!module.isBinary) {
@@ -10,41 +10,33 @@ async function downloadContent(module: IModule): Promise<string> {
   }
 
   return fetch(module.content)
-    .then(x => x.buffer())
-    .then(buffer => buffer.toString("base64"));
+    .then((x) => x.buffer())
+    .then((buffer) => buffer.toString("base64"));
 }
 
 export async function createBlobs(
-  files: string[],
-  sandboxFiles: INormalizedModules,
+  files: Array<{ path: string; content: string; encoding: "base64" | "utf-8" }>,
   gitInfo: IGitInfo,
   token: string
 ): Promise<ITree> {
   return Promise.all(
-    files
-      .map(path => ({ path, file: sandboxFiles[path] }))
-      .filter(({ path, file }) => file.type !== "directory") // Filter directories
-      .map(async ({ path, file }) => {
-        // We handled type in filter
-        const module = (file as unknown) as IModule;
-        const content = await downloadContent(module);
+    files.map(async ({ path, content, encoding }) => {
+      const result = await createBlob(
+        gitInfo.username,
+        gitInfo.repo,
+        content,
+        encoding,
+        token
+      );
 
-        const result = await createBlob(
-          gitInfo.username,
-          gitInfo.repo,
-          content,
-          module.isBinary ? "base64" : "utf-8",
-          token
-        );
-
-        return {
-          path,
-          sha: result.sha,
-          size: module.content.length,
-          mode: "100644", // blob
-          type: "blob",
-          url: result.url
-        };
-      })
+      return {
+        path,
+        sha: result.sha,
+        size: content.length,
+        mode: "100644", // blob
+        type: "blob",
+        url: result.url,
+      };
+    })
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -720,6 +720,11 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
+
 argparse@^1.0.7:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"
@@ -2442,6 +2447,11 @@ detect-newline@2.X, detect-newline@^2.1.0:
 diff@^3.2.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 doctrine@1.5.0, doctrine@^1.2.2:
   version "1.5.0"
@@ -5262,6 +5272,11 @@ make-error@1.x:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
 
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
 make-fetch-happen@^2.4.13:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-2.6.0.tgz#8474aa52198f6b1ae4f3094c04e8370d35ea8a38"
@@ -6976,6 +6991,14 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
+source-map-support@^0.5.17:
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-support@^0.5.6:
   version "0.5.9"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
@@ -7489,6 +7512,17 @@ ts-jest@^23.10.4:
     mkdirp "0.x"
     semver "^5.5"
     yargs-parser "10.x"
+
+ts-node@^8.9.1:
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.9.1.tgz#2f857f46c47e91dcd28a14e052482eb14cfd65a5"
+  integrity sha512-yrq6ODsxEFTLz0R3BX2myf0WBCSQh9A+py8PBo1dCzWIOcvisbyH6akNKqDHMgXePF2kir5mm5JXJTH3OUJYOQ==
+  dependencies:
+    arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
 
 tslib@^1.8.0, tslib@^1.8.1:
   version "1.9.0"
@@ -8031,3 +8065,8 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
There are three main changes here:

1.  The endpoint:

```ts
.post("/git/github/pr/:username/:repo/:branch*/path/:path*", github.pr)
```

now expect to also get a `sandboxId` on its payload. The reason is that it will now branch to the ID of the Sandbox.

2. The endpoint:

```ts
get("/git/github/info/:username/:repo/pull/:pull", github.pullInfo)
```

Now also returns states related to mergeability

3. There is a new endpoint:

```ts
.post("/git/github/compare/:username/:repo/:branch", github.compare)
```

This endpoint allows us to send a BASE to compare to the PR:

```ts
{
  "base": {
    // A commit SHA or a branch
    "ref": "",
     // The owner of the repo, as it might be a fork
     "username": ""
  },
  // Will also return the contents of the file
  "includeContents": true
}
```

So when we load a Codesandbox Draft PR we load it as normal, but in the background the following will happen:

1. We check the current state of the PR, if any, using `pullInfo`. We also load the actual Github source Sandbox which we put into the state. Bear with me on this one 😄 

2. If the Codesandbox PR is not up to date with the latest SHA, on "resolve" click we send a `comparison` request of the current PR `sha` with the new `sha` returned, with contents. This allows us to notify the user that the PR is being updated (Just saves the content to the Sandbox) and if any conflicts those will be resolved with a diff view and an update to the PR is required (new commit)

3. If the Codesandbox PR is up to date we send a `comparison` request of the `originalGitSha` and the current `sha` of the Codesandbox PR, with contents. This gives us all the changes made on this PR. In combination with the source sandbox in the state we have enough data to show an instant indication of changes, both the total changes on PR and any new changes, instantly updated. No big diff async diff requests.

4. If the Codesandbox PR is not in a mergable state, on "resolve" click, we do another `comparison` request where we send the `branch` as the base for comparison, without requiring any content. This gives us a list of files that are different between the updates of the source and your PR. Since we have the source Sandbox we have all the info we need to bring the PR up to date, using diff views where necessary. 

This should give an insanely smooth experience and we replace the heavy `diff` check now by loading the source sandbox into the state as well, giving us a much smoother user experience and avoiding diffing issues. 
