### PR TITLE
expose sha

### DIFF
--- a/packages/import-utils/src/utils/files/denormalize.ts
+++ b/packages/import-utils/src/utils/files/denormalize.ts
@@ -22,6 +22,7 @@ function generateSandboxFile(
     title: basename(path),
     uploadId: module.uploadId,
     isBinary: module.isBinary,
+    sha: module.sha,
   };
 
   if ("binaryContent" in module) {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -2,7 +2,8 @@ export interface IModule {
   content: string; // If isBinary is true this will be a URL
   isBinary: boolean;
   type?: "file";
-  uploadId?: string
+  uploadId?: string;
+  sha?: string;
 }
 
 export interface IBinaryModule extends IModule {
@@ -23,8 +24,9 @@ export interface ISandboxFile {
   shortid: string;
   isBinary: boolean;
   binaryContent?: string;
-  uploadId?: string
+  uploadId?: string;
   directoryShortid: string | undefined | null;
+  sha?: string;
 }
 
 export interface ISandboxDirectory {


### PR DESCRIPTION
We need to expose the `sha` as **GitHub implementation** needs to store new modules using the sha when syncing.