### PR TITLE
Support @roxi/routify import

### DIFF
--- a/packages/import-utils/src/create-sandbox/templates.ts
+++ b/packages/import-utils/src/create-sandbox/templates.ts
@@ -176,7 +176,10 @@ export function getTemplate(
     return "preact-cli";
   }
 
-  if (totalDependencies.indexOf("@sveltech/routify") > -1) {
+  if (
+    totalDependencies.indexOf("@sveltech/routify") > -1 ||
+    totalDependencies.indexOf("@roxi/routify") > -1
+  ) {
     return "node";
   }
 


### PR DESCRIPTION
Add support for the newer @roxi/routify (which is the old @sveltech/routify) template