### PR TITLE
Encode URI for Github API calls to prevent unescaped character errors

### DIFF
--- a/packages/git-extractor/src/routes/github/api.ts
+++ b/packages/git-extractor/src/routes/github/api.ts
@@ -317,7 +317,7 @@ export async function getLatestCommitShaOfFile(
   const response: { data: { sha: string }[] } = await requestAxios(
     "Get Commits of File",
     {
-      url,
+      url: encodeURI(url),
       ...createAxiosRequestConfig(token),
     }
   );


### PR DESCRIPTION
Fixes https://github.com/codesandbox/codesandbox-importers/issues/72 and error often seen in Sentry https://sentry.io/organizations/codesandbox/issues/1958008789/?project=4377691

If a repo has files named with non-English characters, `downloadRepository` fails on `getLatestCommitShaOfFile` and then causes the whole import to fail.

![Screenshot 2021-04-26 at 14 40 34](https://user-images.githubusercontent.com/37520401/116094438-6fc31980-a69f-11eb-8090-b392dbddaf39.png)

Adding `encodeURI` to the url in at least this one place should fix that 👇  🎉 

![Screenshot 2021-04-26 at 14 41 38](https://user-images.githubusercontent.com/37520401/116094514-836e8000-a69f-11eb-910e-78261c999de9.png)
