### PR TITLE
Add logging on request kinds to AppSignal

### DIFF
--- a/packages/git-extractor/src/routes/github/api.ts
+++ b/packages/git-extractor/src/routes/github/api.ts
@@ -45,6 +45,18 @@ function requestAxios(
   return tracer.withSpan(span, (span) => {
     span.setCategory("request-api.github");
     span.setName(requestName);
+    const meter = appsignal.metrics();
+
+    const snakeCaseRequestName = requestName.toLowerCase().replace(/\s/g, "_");
+    meter.incrementCounter(`github_request_${snakeCaseRequestName}`, 1);
+
+    if (requestObject.auth) {
+      // In the case we're using not the user token, let's log that as well!
+      meter.incrementCounter(
+        `github_unauthorized_request_${snakeCaseRequestName}`,
+        1
+      );
+    }
 
     return axios(requestObject)
       .then((res) => {


### PR DESCRIPTION
With this, we'll be able to map out aaalll the requests we do to GitHub, in a single graph. This way we'll know for every request whether we're working on the rate limit.