### PR TITLE
Import an Astro project from GitHub as node template

### DIFF
--- a/packages/import-utils/src/create-sandbox/templates.ts
+++ b/packages/import-utils/src/create-sandbox/templates.ts
@@ -187,6 +187,10 @@ export function getTemplate(
     return "node";
   }
 
+  if (totalDependencies.indexOf("astro") > -1) {
+    return "node";
+  }
+
   if (totalDependencies.indexOf("@frontity/core") > -1) {
     return "node";
   }


### PR DESCRIPTION
Currently, when an Astro project is imported into CodeSandbox, it is interpreted as a React project, and overriding this with "template": "node" is required in a sandbox.config file.

We believe this addition to your import logic should correctly identify Astro on import.