### PR TITLE
Improve package.json Parsing to Detect create-react-app Forks

### DIFF
--- a/packages/import-utils/src/create-sandbox/__tests__/templates.test.ts
+++ b/packages/import-utils/src/create-sandbox/__tests__/templates.test.ts
@@ -8,6 +8,19 @@ describe("template detection", () => {
           dependencies: {},
           devDependencies: {
             "react-scripts": "latest",
+          },
+        },
+        {}
+      )
+    ).toEqual("create-react-app");
+  });
+
+  it("detects a react template from forked create-react-app", () => {
+    expect(
+      getTemplate(
+        {
+          dependencies: {},
+          devDependencies: {
             "@fork/react-scripts": "latest",
           },
         },

--- a/packages/import-utils/src/create-sandbox/__tests__/templates.test.ts
+++ b/packages/import-utils/src/create-sandbox/__tests__/templates.test.ts
@@ -8,6 +8,7 @@ describe("template detection", () => {
           dependencies: {},
           devDependencies: {
             "react-scripts": "latest",
+            "@fork/react-scripts": "latest",
           },
         },
         {}

--- a/packages/import-utils/src/create-sandbox/templates.ts
+++ b/packages/import-utils/src/create-sandbox/templates.ts
@@ -169,7 +169,11 @@ export function getTemplate(
     return "styleguidist";
   }
 
-  if (totalDependencies.indexOf("react-scripts") > -1) {
+  if (
+    totalDependencies.some((dependency) =>
+      /^(@[\w-]+\/)?react-scripts$/.test(dependency)
+    )
+  ) {
     return "create-react-app";
   }
 


### PR DESCRIPTION
Description:
This pull request aims to enhance the package.json parsing functionality in `codesandbox-importers` to include the detection of create-react-app forks. Currently, `codesandbox-importers` detects only the presence of `react-scripts` in the package.json file but not `@fork/react-scripts` for React applications. So, it does not account for the increasing number of forks that offer extended functionalities, customizations, or tailored setups. Many developers rely on create-react-app forks that cater to specific project requirements or provide additional features. By enhancing the package.json parsing, `codesandbox-importers` can better recognize and accommodate these create-react-app forks, ensuring a seamless and comprehensive experience for developers.

The proposed implementation involves enhancing the package.json parsing logic in  `codesandbox-importers` to recognize not only the original create-react-app but also its forks. This will be achieved by considering additional patterns and identifiers commonly associated with create-react-app forks. I strongly believe that this change will significantly enhance the capabilities of  `codesandbox-importers` and better align them with the evolving needs of React developers using create-react-app forks.

The main changes this PR introduced are as follows


1. Using regular expressions to check these patterns `react-scripts` or `@<anything>/react-scripts`
```diff
- if (totalDependencies.indexOf("react-scripts") > -1) {
+ if (totalDependencies.some((dependency) => /^(@[\w-]+\/)?react-scripts$/.test(dependency))) {
    return "create-react-app";
  }
```

2. Adding the test
```ts
  it("detects a react template from forked create-react-app", () => {
    expect(
      getTemplate(
        {
          dependencies: {},
          devDependencies: {
            "@fork/react-scripts": "latest",
          },
        },
        {}
      )
    ).toEqual("create-react-app");
  });
```
[JS Fiddle To the Regex used](https://jsfiddle.net/b3980zgs/3/)


