### PR TITLE
Fix possible null packageJsonPackage

### DIFF
--- a/packages/import-utils/src/create-sandbox/index.ts
+++ b/packages/import-utils/src/create-sandbox/index.ts
@@ -87,10 +87,10 @@ function getSandboxMetadata(
   let packageJsonPackage = packageJson ? JSON.parse(packageJson.content) : null;
 
   const packageJsonInfo = {
-    title: packageJsonPackage.title || packageJsonPackage.name,
-    description: packageJsonPackage.description,
-    tags: packageJsonPackage.keywords || [],
-    iconUrl: packageJsonPackage.iconUrl,
+    title: packageJsonPackage?.title || packageJsonPackage?.name,
+    description: packageJsonPackage?.description,
+    tags: packageJsonPackage?.keywords || [],
+    iconUrl: packageJsonPackage?.iconUrl,
   };
 
   const templateInfo = directory[".codesandbox/template.json"];


### PR DESCRIPTION
Pretty sure this is the issue that causes errors on any sandbox that does not contain a `package.json`, but we should verify with some test sandboxes.