### PR TITLE
Add van-js and mini-van-plate as server dependencies

### DIFF
--- a/packages/import-utils/src/create-sandbox/templates.ts
+++ b/packages/import-utils/src/create-sandbox/templates.ts
@@ -155,6 +155,14 @@ export function getTemplate(
     return "node";
   }
 
+  if (totalDependencies.indexOf("vanjs-core") > -1) {
+    return "node";
+  }
+
+  if (totalDependencies.indexOf("mini-van-plate") > -1) {
+    return "node";
+  }
+
   // CLIENT
 
   if (moduleNames.some((m) => m.endsWith(".re"))) {


### PR DESCRIPTION
Requested by a maintainer in support because their GH templates need to be cloud sandboxes.